### PR TITLE
Add resetContainer action to HOC

### DIFF
--- a/src/components/Entities.js
+++ b/src/components/Entities.js
@@ -49,7 +49,10 @@ const containerPropTypes = {
   total: PropTypes.number,
 
   /** Update the filters for this container. */
-  updateFilters: PropTypes.func
+  updateFilters: PropTypes.func,
+
+  /** Resets the state of this container */
+  resetContainer: PropTypes.func
 }
 
 const initializeContainer = (props, config) => {
@@ -145,7 +148,8 @@ const createMapDispatch = (containers, containerKeys) => (initialDispatch, initi
       fetchAll: EntitiesModule.actions.S.FETCH_ALL.trigger,
       initialize: EntitiesModule.actions.S.INITIALIZE_CONTAINER.trigger,
       performAction: EntitiesModule.actions.S.PERFORM_ACTION.trigger,
-      updateFilters: EntitiesModule.actions.S.UPDATE_FILTERS.trigger
+      updateFilters: EntitiesModule.actions.S.UPDATE_FILTERS.trigger,
+      resetContainer: EntitiesModule.actions.D.resetContainerData
     }, initialDispatch, defaultPayload)
 
     // For backwards compatibility with item/collection

--- a/src/components/Entities.spec.js
+++ b/src/components/Entities.spec.js
@@ -202,6 +202,11 @@ describe('components.Entities', () => {
         const result = actions.contactResource.updateFilters()
         expect(initialDispatch).toBeCalled()
       })
+
+      it('resetContainer', () => {
+        const result = actions.contactResource.resetContainer()
+        expect(initialDispatch.mock.calls[initialDispatch.mock.calls.length - 1]).toMatchSnapshot()
+      })
     })
   })
 })

--- a/src/components/__snapshots__/Entities.spec.js.snap
+++ b/src/components/__snapshots__/Entities.spec.js.snap
@@ -15,6 +15,19 @@ Array [
 ]
 `;
 
+exports[`components.Entities createMapDispatch binding actions resetContainer 1`] = `
+Array [
+  Object {
+    "error": undefined,
+    "payload": Object {
+      "containerId": "contacts-container",
+      "type": "contact",
+    },
+    "type": "D/entities/RESET_CONTAINER_DATA",
+  },
+]
+`;
+
 exports[`components.Entities createMapState gets state 1`] = `
 Object {
   "bucketResource": Object {
@@ -109,6 +122,7 @@ Object {
   "meta": Immutable.Map {},
   "missingIds": Immutable.Set [],
   "performAction": [Function],
+  "resetContainer": [Function],
   "total": 0,
   "updateCollection": [Function],
   "updateFilters": [Function],
@@ -128,6 +142,7 @@ Object {
   "meta": Immutable.Map {},
   "missingIds": Immutable.Set [],
   "performAction": [Function],
+  "resetContainer": [Function],
   "total": 0,
   "updateCollection": [Function],
   "updateFilters": [Function],

--- a/src/module/sagas/updateFilters.js
+++ b/src/module/sagas/updateFilters.js
@@ -14,14 +14,9 @@ function* updateFilters (givenPayload = {}) {
     containerId,
     filters = {},
     debounce = true,
-    resetContainer = false,
     resetFilters = false,
     ...rest
   } = givenPayload
-
-  if (resetContainer) {
-    yield put(actions.D.resetContainerData({containerId}))
-  }
 
   // When a filter other than the page changes, move back to the first page.
   if (!filters.page) { filters.page = 1 }

--- a/src/module/sagas/updateFilters.js
+++ b/src/module/sagas/updateFilters.js
@@ -7,6 +7,9 @@ import performAction from './performAction'
  * Update the filters for a given container.
  *
  * @param  {object} givenPayload
+ * @param  {object} filters the new filters
+ * @param  {boolean=true} debounce if true, the fetch side-effect will be debounced by 400ms
+ * @param  {boolean=false} resetFilters if true, filters will be replaced with the given `filters` param. If false, they will be merged with the current filters.
  * @return {void}
  */
 function* updateFilters (givenPayload = {}) {

--- a/src/module/sagas/updateFilters.spec.js
+++ b/src/module/sagas/updateFilters.spec.js
@@ -91,21 +91,4 @@ describe('entities.sagas.updateFilters', () => {
       expect(generator.next().value).toMatchObject(expectedEffect)
     })
   })
-
-  describe('with resetContainer: true', () => {
-    const payload = {
-      containerId,
-      filters: { team_search: true, page: 2 },
-      resetContainer: true
-    }
-    const generator = updateFilters(payload)
-
-    test('resets the container', () => {
-      const expectedEffect = put(actions.D.resetContainerData({
-        containerId
-      }))
-
-      expect(generator.next().value).toMatchObject(expectedEffect)
-    })
-  })
 })

--- a/src/test-utils/mockEntities.js
+++ b/src/test-utils/mockEntities.js
@@ -69,7 +69,10 @@ mockEntities.stub = (options) => {
     updateFilters: options.updateFilters || mockFn(),
 
     /** Update the filters for this container. Uses existing filters. */
-    updateCollection: options.updateCollection || mockFn()
+    updateCollection: options.updateCollection || mockFn(),
+
+    /** Resets the container */
+    resetContainer: options.resetContainer || mockFn()
   }
 }
 


### PR DESCRIPTION
- Removes the `updateFilters` option from `updateFilters`
- Adds a `resetContainer` dispatch to the Entities HOC, which resets the container to it's initial, empty state.