### PR TITLE
Pass type prop through mapDispatch and mapState over container type

### DIFF
--- a/src/components/Entities.js
+++ b/src/components/Entities.js
@@ -48,6 +48,9 @@ const containerPropTypes = {
   /** Total entities in a given collection. */
   total: PropTypes.number,
 
+  /** Type of the collecton associated with resource config */
+  type: PropTypes.string,
+
   /** Update the filters for this container. */
   updateFilters: PropTypes.func,
 
@@ -109,7 +112,7 @@ const createMapState = (containers, containerKeys) => (initialState, initialProp
   // Needs to be a function so that redux will use this as the
   // mapStateToProps function on subsequent renders.
   return (globalState, props) => containerKeys.reduce((memo, key) => {
-    const containerProps = { ...props[key], type: containers[key].type }
+    const containerProps = { type: containers[key].type, ...props[key] }
     if (containers[key].getId) {
       containerProps.ids = containers[key].getId({ ...props, ...memo }) || defaultPassedIds
     } else if (props.itemId) {
@@ -121,6 +124,7 @@ const createMapState = (containers, containerKeys) => (initialState, initialProp
 
     memo[key] = {
       items,
+      type: containerProps.type,
       missingIds: selectors[key].missingIds(globalState, containerProps),
 
       // Convenience helpers derived from state/items
@@ -141,7 +145,7 @@ const createMapDispatch = (containers, containerKeys) => (initialDispatch, initi
   const boundActions = containerKeys.reduce((memo, key) => {
     const defaultPayload = {
       containerId: initialProps[key].containerId,
-      type: containers[key].type
+      type: initialProps[key].type || containers[key].type
     }
 
     memo[key] = bindActionCreators({

--- a/src/components/Entities.spec.js
+++ b/src/components/Entities.spec.js
@@ -162,6 +162,20 @@ describe('components.Entities', () => {
       expect(fromJS(result).toJS()).toMatchSnapshot()
     })
 
+    it('uses passed type over container type', () => {
+      const mapState = createMapState(containers, containerKeys)
+      const resultFn = mapState(initialState, initialProps)
+      const globalState = stubStore({
+        containers: {
+          'contacts-container': stubContainer({}),
+          'buckets-container': stubContainer({})
+        }
+      })
+      const props = {contactResource: {type: 'bucket'}}
+      const result = resultFn(globalState, props)
+      expect(result.contactResource.type).toEqual('bucket')
+    })
+
     it('sets isLoading when a container has activeRequests', () => {
       const mapState = createMapState(containers, containerKeys)
       const resultFn = mapState(initialState, initialProps)
@@ -242,6 +256,19 @@ describe('components.Entities', () => {
       it('resetContainer', () => {
         const result = actions.contactResource.resetContainer()
         expect(initialDispatch.mock.calls[initialDispatch.mock.calls.length - 1]).toMatchSnapshot()
+      })
+
+      describe('when passed a type prop', () => {
+        it('uses the passed prop over container prop', () => {
+          let actions
+          const mapDispatch = createMapDispatch(containers, containerKeys)
+          initialProps.contactResource = {containerId: 'contacts-container', type: 'bucket'}
+          const resultFn = mapDispatch(initialDispatch, initialProps)
+          actions = resultFn()
+          actions.contactResource.fetchAll()
+          const lastMockCall = initialDispatch.mock.calls.length - 1
+          expect(initialDispatch.mock.calls[lastMockCall][0].payload.type).toEqual('bucket')
+        })
       })
     })
   })

--- a/src/components/__snapshots__/Entities.spec.js.snap
+++ b/src/components/__snapshots__/Entities.spec.js.snap
@@ -40,6 +40,7 @@ Object {
     "meta": Object {},
     "missingIds": Array [],
     "total": 0,
+    "type": "bucket",
   },
   "contactResource": Object {
     "errors": Object {},
@@ -51,6 +52,7 @@ Object {
     "meta": Object {},
     "missingIds": Array [],
     "total": 0,
+    "type": "contact",
   },
 }
 `;
@@ -67,6 +69,7 @@ Object {
     "meta": Immutable.Map {},
     "missingIds": Immutable.Set [],
     "total": 0,
+    "type": "bucket",
   },
   "contactResource": Object {
     "errors": Immutable.Map {},
@@ -78,6 +81,7 @@ Object {
     "meta": Immutable.Map {},
     "missingIds": Immutable.Set [],
     "total": 0,
+    "type": "contact",
   },
 }
 `;
@@ -94,6 +98,7 @@ Object {
     "meta": Immutable.Map {},
     "missingIds": Immutable.Set [],
     "total": 0,
+    "type": "bucket",
   },
   "contactResource": Object {
     "errors": Immutable.Map {},
@@ -105,6 +110,7 @@ Object {
     "meta": Immutable.Map {},
     "missingIds": Immutable.Set [],
     "total": 0,
+    "type": "contact",
   },
 }
 `;
@@ -126,6 +132,7 @@ Object {
   "performAction": [Function],
   "resetContainer": [Function],
   "total": 0,
+  "type": "bucket",
   "updateCollection": [Function],
   "updateFilters": [Function],
 }
@@ -148,6 +155,7 @@ Object {
   "performAction": [Function],
   "resetContainer": [Function],
   "total": 0,
+  "type": "contact",
   "updateCollection": [Function],
   "updateFilters": [Function],
 }

--- a/src/test-utils/mockEntities.js
+++ b/src/test-utils/mockEntities.js
@@ -66,7 +66,7 @@ mockEntities.stub = (options) => {
     total: options.total || 0,
 
     /** Type of entity from resource config */
-    type: options.type
+    type: options.type,
 
     /** Update the filters for this container. */
     updateFilters: options.updateFilters || mockFn(),

--- a/src/test-utils/mockEntities.js
+++ b/src/test-utils/mockEntities.js
@@ -65,6 +65,9 @@ mockEntities.stub = (options) => {
     /** Total entities in a given collection. */
     total: options.total || 0,
 
+    /** Type of entity from resource config */
+    type: options.type
+
     /** Update the filters for this container. */
     updateFilters: options.updateFilters || mockFn(),
 


### PR DESCRIPTION
Allows a user to pass in a prop that has a type rather than using the type in the entities configuration object. This is necessary to allow dynamic types. 

For example, a user might want a component that would sometimes be wrapped with Contacts, but other times wrapped with Users data. Now you can specify which type that component should use.